### PR TITLE
Move theme changes to `extend` so they don't override defaults

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,16 @@
 module.exports = {
   theme: {
-    zIndex: {
-      '1': 1
-    },
-    maxWidth: {
-      '500px': '500px',
-    },
-    fontFamily: {
-      'mono': ['Roboto Mono', 'monospace']
-    },
-    extend: {}
+    extend: {
+      zIndex: {
+        '1': 1
+      },
+      maxWidth: {
+        '500px': '500px',
+      },
+      fontFamily: {
+        'mono': ['Roboto Mono', 'monospace']
+      },
+    }
   },
   variants: {},
   plugins: []


### PR DESCRIPTION
By putting things directly under `theme`, you are _overriding_ all of the default values, so `z-0` doesn't exist. If all you want to do is add additional values, you should use `extend` 👍 

https://tailwindcss.com/docs/theme/#extending-the-default-theme